### PR TITLE
docs: fix broken star history chart across READMEs

### DIFF
--- a/README-lang/README-ar.md
+++ b/README-lang/README-ar.md
@@ -184,7 +184,7 @@
 
 ## 🌟 سجل النجوم
 
-[![Star History Chart](https://api.star-history.com/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.com/#rockbenben/ChatGPT-Shortcut&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.dera.page/#rockbenben/ChatGPT-Shortcut&Date)
 
 ## 📜 الترخيص
 

--- a/README-lang/README-bn.md
+++ b/README-lang/README-bn.md
@@ -184,7 +184,7 @@ Vercel, Cloudflare Pages, Docker বা স্থানীয়ভাবে আ
 
 ## 🌟 স্টার ইতিহাস
 
-[![Star History Chart](https://api.star-history.com/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.com/#rockbenben/ChatGPT-Shortcut&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.dera.page/#rockbenben/ChatGPT-Shortcut&Date)
 
 ## 📜 লাইসেন্স
 

--- a/README-lang/README-de.md
+++ b/README-lang/README-de.md
@@ -184,7 +184,7 @@ Treten Sie uns bei für Diskussionen und Feedback:
 
 ## 🌟 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.com/#rockbenben/ChatGPT-Shortcut&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.dera.page/#rockbenben/ChatGPT-Shortcut&Date)
 
 ## 📜 Lizenz
 

--- a/README-lang/README-es.md
+++ b/README-lang/README-es.md
@@ -184,7 +184,7 @@ Para la configuración del desarrollo local, consulta la [Guía de Despliegue](h
 
 ## 🌟 Historial de Stars
 
-[![Star History Chart](https://api.star-history.com/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.com/#rockbenben/ChatGPT-Shortcut&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.dera.page/#rockbenben/ChatGPT-Shortcut&Date)
 
 ## 📜 Licencia
 

--- a/README-lang/README-fr.md
+++ b/README-lang/README-fr.md
@@ -184,7 +184,7 @@ Rejoignez-nous pour les discussions et retours :
 
 ## 🌟 Historique des Stars
 
-[![Star History Chart](https://api.star-history.com/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.com/#rockbenben/ChatGPT-Shortcut&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.dera.page/#rockbenben/ChatGPT-Shortcut&Date)
 
 ## 📜 Licence
 

--- a/README-lang/README-hi.md
+++ b/README-lang/README-hi.md
@@ -184,7 +184,7 @@ Vercel, Cloudflare Pages, Docker या स्थानीय रूप से �
 
 ## 🌟 Star इतिहास
 
-[![Star History Chart](https://api.star-history.com/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.com/#rockbenben/ChatGPT-Shortcut&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.dera.page/#rockbenben/ChatGPT-Shortcut&Date)
 
 ## 📜 लाइसेंस
 

--- a/README-lang/README-ind.md
+++ b/README-lang/README-ind.md
@@ -184,7 +184,7 @@ Bergabunglah bersama kami untuk diskusi dan umpan balik:
 
 ## 🌟 Riwayat Star
 
-[![Star History Chart](https://api.star-history.com/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.com/#rockbenben/ChatGPT-Shortcut&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.dera.page/#rockbenben/ChatGPT-Shortcut&Date)
 
 ## 📜 Lisensi
 

--- a/README-lang/README-it.md
+++ b/README-lang/README-it.md
@@ -184,7 +184,7 @@ Unisciti per discussioni e feedback:
 
 ## 🌟 Cronologia Star
 
-[![Star History Chart](https://api.star-history.com/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.com/#rockbenben/ChatGPT-Shortcut&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.dera.page/#rockbenben/ChatGPT-Shortcut&Date)
 
 ## 📜 Licenza
 

--- a/README-lang/README-ja.md
+++ b/README-lang/README-ja.md
@@ -184,7 +184,7 @@ Vercel、Cloudflare Pages、Docker、またはローカル環境でデプロイ�
 
 ## 🌟 Star 履歴
 
-[![Star History Chart](https://api.star-history.com/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.com/#rockbenben/ChatGPT-Shortcut&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.dera.page/#rockbenben/ChatGPT-Shortcut&Date)
 
 ## 📜 ライセンス
 

--- a/README-lang/README-ko.md
+++ b/README-lang/README-ko.md
@@ -184,7 +184,7 @@ Vercel, Cloudflare Pages, Docker 또는 로컬에서 인스턴스를 배포할 �
 
 ## 🌟 Star 히스토리
 
-[![Star History Chart](https://api.star-history.com/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.com/#rockbenben/ChatGPT-Shortcut&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.dera.page/#rockbenben/ChatGPT-Shortcut&Date)
 
 ## 📜 라이선스
 

--- a/README-lang/README-pt.md
+++ b/README-lang/README-pt.md
@@ -184,7 +184,7 @@ Junte-se para discussões e feedback:
 
 ## 🌟 Histórico de Stars
 
-[![Star History Chart](https://api.star-history.com/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.com/#rockbenben/ChatGPT-Shortcut&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.dera.page/#rockbenben/ChatGPT-Shortcut&Date)
 
 ## 📜 Licença
 

--- a/README-lang/README-ru.md
+++ b/README-lang/README-ru.md
@@ -184,7 +184,7 @@
 
 ## 🌟 История Star
 
-[![Star History Chart](https://api.star-history.com/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.com/#rockbenben/ChatGPT-Shortcut&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.dera.page/#rockbenben/ChatGPT-Shortcut&Date)
 
 ## 📜 Лицензия
 

--- a/README-lang/README-th.md
+++ b/README-lang/README-th.md
@@ -184,7 +184,7 @@
 
 ## 🌟 ประวัติ Star
 
-[![Star History Chart](https://api.star-history.com/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.com/#rockbenben/ChatGPT-Shortcut&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.dera.page/#rockbenben/ChatGPT-Shortcut&Date)
 
 ## 📜 ใบอนุญาต
 

--- a/README-lang/README-tr.md
+++ b/README-lang/README-tr.md
@@ -184,7 +184,7 @@ Tartışmalar ve geri bildirimler için bize katılın:
 
 ## 🌟 Star Geçmişi
 
-[![Star History Chart](https://api.star-history.com/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.com/#rockbenben/ChatGPT-Shortcut&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.dera.page/#rockbenben/ChatGPT-Shortcut&Date)
 
 ## 📜 Lisans
 

--- a/README-lang/README-vi.md
+++ b/README-lang/README-vi.md
@@ -183,7 +183,7 @@ Tham gia cùng chúng tôi để thảo luận và phản hồi:
 
 ## 🌟 Lịch sử Star
 
-[![Star History Chart](https://api.star-history.com/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.com/#rockbenben/ChatGPT-Shortcut&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.dera.page/#rockbenben/ChatGPT-Shortcut&Date)
 
 ## 📜 Giấy phép
 

--- a/README-lang/README-zh-hant.md
+++ b/README-lang/README-zh-hant.md
@@ -186,7 +186,7 @@ AiShort 擴充套件讓你隨時呼叫提示詞庫。支援 Chrome、Edge、Fire
 
 ## 🌟 Star 歷史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.com/#rockbenben/ChatGPT-Shortcut&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.dera.page/#rockbenben/ChatGPT-Shortcut&Date)
 
 ## 📜 開源協議
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -186,7 +186,7 @@ AiShort 扩展让你随时调用提示词库。支持 Chrome、Edge、Firefox，
 
 ## 🌟 Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.com/#rockbenben/ChatGPT-Shortcut&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.dera.page/#rockbenben/ChatGPT-Shortcut&Date)
 
 ## 📜 开源协议
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Join us for discussions and feedback:
 
 ## 🌟 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.com/#rockbenben/ChatGPT-Shortcut&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=rockbenben/ChatGPT-Shortcut&type=Date)](https://star-history.dera.page/#rockbenben/ChatGPT-Shortcut&Date)
 
 ## 📜 License
 


### PR DESCRIPTION
The star history chart in the README (and all localized versions) is currently broken and no longer renders, because the underlying GitHub stargazer API restricts the requests the chart depends on. This change points the chart, and the link that wraps it, at a working source (star-history.dera.page) so the chart displays correctly again across the main and translated READMEs.